### PR TITLE
Save PlayerPrefs to disk

### DIFF
--- a/Assets/SettingsMenu.cs
+++ b/Assets/SettingsMenu.cs
@@ -116,6 +116,7 @@ public class SettingsMenu : MonoBehaviour
         PlayerPrefs.SetInt("AntiAliasingPreference", aaDropdown.value);
         PlayerPrefs.SetInt("FullscreenPreference", Convert.ToInt32(Screen.fullScreen));
         PlayerPrefs.SetFloat("VolumePreference", currentVolume);
+        PlayerPrefs.Save();
     }
 
     public void LoadSettings(int currentResolutionIndex)


### PR DESCRIPTION
Not sure if this was the behavior when the article was written, but at the moment you must have `PlayerPrefs.Save();` for the settings to be saved to the disk.